### PR TITLE
feature/gemify: Create a gem with an executable from git-changelog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.2.0'
+ruby '2.2.2'
 # ruby-gemset=rails
 
 gem 'rugged'

--- a/bin/changelog
+++ b/bin/changelog
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
+require "changelog_helpers"
 require "docopt"
 require "logger"
 require "rugged"
-require "./lib/changelog_helpers"
 require "pry"
 
 
@@ -95,7 +95,7 @@ if args["--complete"] && repo.tags.count > 0
     end
   end
 
-  if sorted_tags.count > 0 
+  if sorted_tags.count > 0
     lastTag = sorted_tags.last
     # Last Interval: Generate from last Tag to HEAD
     changes = searchGitLog(repo, repo.head.target, lastTag.target, logger)

--- a/git-changelog.gemspec
+++ b/git-changelog.gemspec
@@ -1,0 +1,13 @@
+Gem::Specification.new do |s|
+  s.name        = 'git-changelog'
+  s.version     = '0.2.2'
+  s.date        = '2015-07-07'
+  s.summary     = "Generate a changelog from a git repository"
+  s.description = "Generate a changelog from a git repository"
+  s.authors     = ["Markus Chmelar"]
+  s.email       = 'markus.chmelar@innovaptor.com'
+  s.files       = ["bin/changelog","lib/changelog_helpers.rb"]
+  s.homepage    = 'https://github.com/iv-mexx/git-changelog'
+  s.license     = 'MIT'
+  s.executables = "changelog"
+end


### PR DESCRIPTION
Change structure and create files in order to use git-changelog as a gem with an executable.

To test the gem, execute the following in the repository:
```sh
gem build git-changelog.gemspec
gem install git-changelog-0.2.2.gem
```

You should now have an executable called `changelog`. Example execution: `changelog.rb v1.0`.