### PR TITLE
feature/dryformat: Refactor changelog generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+
+rvm:
+  - 2.0.0
+
+notifications:
+  email:
+    recipients:
+      - lukas.nagl@innovaptor.com
+      - markus.chmelar@innovaptor.com
+    on_failure: change
+    on_success: never

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "rugged", :git => "git@github.com:libgit2/rugged.git", :tag => "v0.23.0b4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     git-changelog (0.5.1)
       docopt (~> 0.5, >= 0.5.0)
-      rugged
+      rugged (>= 0.23.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+PATH
+  remote: .
+  specs:
+    git-changelog (0.5.1)
+      docopt (~> 0.5, >= 0.5.0)
+      rugged
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    docopt (0.5.0)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.1)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    rugged (0.23.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  git-changelog!
+  rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,4 +30,4 @@ PLATFORMS
 
 DEPENDENCIES
   git-changelog!
-  rspec
+  rspec (~> 3.3.0)

--- a/git-changelog.gemspec
+++ b/git-changelog.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.executables = "git-changelog"
   s.add_runtime_dependency 'docopt', '~> 0.5', '>= 0.5.0'
-  s.add_runtime_dependency 'rugged'
+  s.add_runtime_dependency 'rugged', '>= 0.23.0'
   s.add_development_dependency 'rspec', '~> 3.3.0'
 end

--- a/git-changelog.gemspec
+++ b/git-changelog.gemspec
@@ -6,10 +6,11 @@ Gem::Specification.new do |s|
   s.description = "Write your changelog as you go into your commit messages. This tool generates a useful changelog from marked lines in your git commit messages"
   s.authors     = ["Markus Chmelar"]
   s.email       = 'markus.chmelar@innovaptor.com'
-  s.files       = ["bin/git-changelog","lib/changelog_helpers.rb","lib/git-changelog.rb"]
+  s.files       = ["bin/git-changelog","lib/changelog_helpers.rb","lib/git-changelog.rb", "lib/changelog.rb"]
   s.homepage    = 'https://github.com/iv-mexx/git-changelog'
   s.license     = 'MIT'
   s.executables = "git-changelog"
   s.add_runtime_dependency 'docopt', '~> 0.5', '>= 0.5.0'
   s.add_runtime_dependency 'rugged'
+  s.add_development_dependency 'rspec', '~> 3.3.0'
 end

--- a/lib/changelog.rb
+++ b/lib/changelog.rb
@@ -1,0 +1,111 @@
+# A class for representing a changelog consisting of several changes
+# over a certain timespan (between two commits)
+class Changelog
+  def initialize(changes, tag_from = nil, tag_to = nil, from_commit = nil, to_commit = nil)
+    @fixes = changes.select { |c| c.type == Change::FIX }
+    @features = changes.select { |c| c.type == Change::FEAT }
+    @gui_changes = changes.select { |c| c.type == Change::GUI }
+    @refactorings = changes.select { |c| c.type == Change::REFACTORING }
+    @tag_from = tag_from
+    @tag_to = tag_to
+    @commit_from = from_commit
+    @commit_to = to_commit
+  end
+
+  def changes
+    {
+      fixes: @fixes.map(&:note),
+      features: @features.map(&:note),
+      gui: @gui_changes.map(&:note),
+      refactoring: @refactorings.map(&:note)
+    }
+  end
+
+  # Display tag information about the tag that the changelog is created for
+  def tag_info
+    if @tag_to && @tag_to.name
+      yield("#{@tag_to.name}")
+    else
+      yield("Unreleased")
+    end
+  end
+
+  # Display tinformation about the commit the changelog is created for
+  def commit_info
+    if @commit_from
+      yield(@commit_to.time.strftime("%d.%m.%Y"))
+    else
+      yield("")
+    end
+  end
+
+  # Format each section from #sections.
+  #
+  # section_changes ... changes in the format of { section_1: [changes...], section_2: [changes...]}
+  # header_style ... is called for styling the header of each section
+  # entry_style ... is called for styling each item of a section
+  def sections(section_changes, header_style, entry_style)
+    str = ""
+    section_changes.each do |section_category, section_changes|
+      str << section(
+        section_changes,
+        section_category.to_s,
+        entry_style,
+        header_style
+      )
+    end
+    str
+  end
+
+  # Format a specific section.
+  #
+  # section_changes ... changes in the format of { section_1: [changes...], section_2: [changes...]}
+  # header ... header of the section
+  # entry_style ... is called for styling each item of a section
+  # header_style ... optional, since styled header can be passed directly; is called for styling the header of the section
+  def section(section_changes, header, entry_style, header_style = nil)
+    return "" unless section_changes.size > 0
+    str = ""
+
+    unless header.empty?
+      if header_style
+        str << header_style.call(header)
+      else
+        str << header
+      end
+    end
+
+    section_changes.each_with_index do |e, i|
+      str << entry_style.call(e, i)
+    end
+    str
+  end
+
+  def to_slack
+    str = ""
+
+    str << tag_info { |t| t }
+    str << commit_info { |ci| " (_#{ci}_)\n" }
+    str << sections(
+      changes,
+      -> (header) { "*#{header.capitalize}*\n" },
+      -> (field, _index) { "\t- #{field}\n" }
+    )
+
+    str
+  end
+
+  def to_md
+    str = ""
+
+    str << tag_info { |t| "## #{t}" }
+    str << commit_info { |ci| " (_#{ci}_)" }
+    str << sections(
+      changes,
+      -> (header) { "\n*#{header.capitalize}*\n" },
+      -> (field, _index) { "* #{field}\n" }
+    )
+
+    str
+  end
+end

--- a/lib/changelog.rb
+++ b/lib/changelog.rb
@@ -32,7 +32,7 @@ class Changelog
 
   # Display tinformation about the commit the changelog is created for
   def commit_info
-    if @commit_from
+    if @commit_to
       yield(@commit_to.time.strftime("%d.%m.%Y"))
     else
       yield("")

--- a/lib/changelog_helpers.rb
+++ b/lib/changelog_helpers.rb
@@ -1,6 +1,6 @@
-# 
+#
 # Helper Functions for git-changelog script
-# 
+#
 
 # A class for representing a change
 # A change can have a type (fix or feature) and a note describing the change
@@ -44,7 +44,7 @@ class Change
 
   def check_scope(scope = nil)
     # If no scope is requested or the change has no scope include this change unchanged
-    return self unless scope 
+    return self unless scope
     change_scope = /^\s*\[\w+\]/.match(@note)
     return self unless change_scope
 
@@ -52,114 +52,14 @@ class Change
       #  Change has the scope that is requested, strip the scope from the change note
       @note = change_scope.post_match.strip
       return self
-    else 
+    else
       #  Change has a different scope than requested
       return nil
     end
   end
 end
 
-# A class for representing a changelog consisting of several changes
-# over a certain timespan (between two commits)
-class Changelog
-  def initialize(changes, tag_from = nil, tag_to = nil, from_commit = nil, to_commit = nil)
-    @fixes = changes.select{ |c| c.type == Change::FIX }
-    @features = changes.select{ |c| c.type == Change::FEAT }
-    @gui_changes = changes.select{ |c| c.type == Change::GUI }
-    @refactorings = changes.select{ |c| c.type == Change::REFACTORING }
-    @tag_from = tag_from
-    @tag_to = tag_to
-    @commit_from = from_commit
-    @commit_to = to_commit
-  end
-
-  def changes
-    {
-      fixes: @fixes.map{|c| c.note},
-      features: @features.map{|c| c.note},
-      gui_changes: @gui_changes.map{|c| c.note},
-      refactorings: @refactorings.map{|c| c.note}
-    }
-  end
-
-  def to_slack
-    str = ""
-
-    if @tag_from && @tag_from.name 
-      str << "Version #{@tag_from.name}"
-    else
-      str << "Unreleased"
-    end
-
-    if @commit_from
-      str << " (_#{@commit_from.time.strftime("%d.%m.%Y")}_)"
-    end
-    str << "\n"
-
-    if @fixes.count > 0
-      str << "*Fixes*\n"
-      str << @fixes.map{|c| "\t- #{c.note}"}.join("\n")
-    end
-
-    if @features.count > 0
-      str << "\n\n*Features*\n"
-      str << @features.map{|c| "\t- #{c.note}"}.join("\n")
-    end
-
-    if @gui_changes.count > 0
-      str << "\n\n*GUI*\n"
-      str << @gui_changes.map{|c| "\t- #{c.note}"}.join("\n")
-    end
-
-    if @refactorings.count > 0
-      str << "\n\n*REFACTORING*\n"
-      str << @refactorings.map{|c| "\t- #{c.note}"}.join("\n")
-    end
-
-    str << "\n"
-    str    
-  end
-
-  def to_md
-    str = ""
-
-    if @tag_from && @tag_from.name 
-      str << "## Version #{@tag_from.name}"
-    else
-      str << "## Unreleased"
-    end
-
-    if @commit_from
-      str << " (_#{@commit_from.time.strftime("%d.%m.%Y")}_)"
-    end
-    str << "\n"
-
-    if @fixes.count > 0
-      str << "*Fixes*\n"
-      str << @fixes.map{|c| "* #{c.note}"}.join("\n")
-    end
-
-    if @features.count > 0
-      str << "\n\n*Features*\n"
-      str << @features.map{|c| "* #{c.note}"}.join("\n")
-    end
-
-    if @gui_changes.count > 0
-      str << "\n\n*GUI*\n"
-      str << @gui_changes.map{|c| "* #{c.note}"}.join("\n")
-    end
-
-    if @refactorings.count > 0
-      str << "\n\n*REFACTORING*\n"
-      str << @refactorings.map{|c| "* #{c.note}"}.join("\n")
-    end
-
-    str << "\n"
-    str    
-  end
-end
-
-# check if the given refString (tag name or commit-hash) exists in the repo 
+# check if the given refString (tag name or commit-hash) exists in the repo
 def commit(repo, refString, logger)
   return unless refString != nil
   begin

--- a/lib/git-changelog.rb
+++ b/lib/git-changelog.rb
@@ -1,5 +1,6 @@
 require "rugged"
 require "changelog_helpers"
+require "changelog"
 require "logger"
 
 class Changelog
@@ -89,11 +90,12 @@ class Changelog
       log = Changelog.new(changes, from_ref, to_ref || latest_tag, commit_from, commit_to)
 
       # Print the changelog
-      if format == "md"
+      case format
+      when "md"
         log.to_md
-      elsif format == "slack"
+      when "slack"
         log.to_slack
-      elsif format == "raw"
+      when "raw"
         log
       else
         logger.error("Unknown Format: `#{format}`")

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'changelog'
+
+describe Changelog do
+  context "without git information" do
+    subject { Changelog.new([]) }
+    let(:changes) do
+      {
+        fixes: ["Did this", "and that"],
+        features: ["and this", "and more"]
+      }
+    end
+
+    describe "single section" do
+      it "should be able to style a section" do
+        generated_string = subject.section(
+          changes[:fixes],
+          "*FIXES*\n",
+          -> (field, _index) { "\t- #{field}\n" }
+        )
+        expect(generated_string).to eq("*FIXES*\n\t- Did this\n\t- and that\n")
+      end
+
+      it "should not style an empty section" do
+        generated_string = subject.section(
+          [],
+          "",
+          -> (field, _index) { "\t- #{field}\n" }
+        )
+        expect(generated_string).to eq("")
+      end
+
+      it "should accept a header style" do
+        generated_string = subject.section(
+          changes[:fixes],
+          "fixes",
+          -> (field, _index) { "\t- #{field}\n" },
+          -> (header) { "*#{header.capitalize}*\n" }
+        )
+        expect(generated_string).to eq("*Fixes*\n\t- Did this\n\t- and that\n")
+      end
+    end
+
+    describe "multiple sections" do
+      it "should be able to style multiple sections" do
+        generated_string = subject.sections(
+         changes,
+          -> (header) { "*#{header.capitalize}*\n" },
+          -> (field, _index) { "\t- #{field}\n" }
+        )
+        expect(generated_string).to eq("*Fixes*\n\t- Did this\n\t- and that\n*Features*\n\t- and this\n\t- and more\n")
+      end
+
+      it "should skip empty sections" do
+        empty_changes = {
+          fixes: [],
+          features: ["and this", "and more"]
+        }
+        generated_string = subject.sections(
+          empty_changes,
+          -> (header) { "*#{header.capitalize}*\n" },
+          -> (field, _index) { "\t- #{field}\n" }
+        )
+        expect(generated_string).to eq("*Features*\n\t- and this\n\t- and more\n")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'bundler/setup'
+Bundler.setup
+
+require 'git-changelog'
+
+RSpec.configure do |config|
+end


### PR DESCRIPTION
# Changes

* refactor: Moved changelog formatting into `lib/changelog.rb`
* refactor: Added various helper methods to make it easier to change formatting output and to make it less error-prone to change displayed information across multiple formats
* refactor: Change `Changelog#changes` to return hash keys `gui` and `refactoring` instead of `gui_changes` and `refactorings`
* fix: During changelog generation, use `commit_to` and `tag_to` instead of `commit_from` and `tag_from` to make an execution like `git-changelog 0.4.0 --format=slack` display information about the version being currently released
* feat: Got us started with a basic rspec setup and some test for the most complicated new methods in `lib/changelog.rb`
* feat: Add basic .travis.yml file to be able to start with CI

# Testing

* Please especially check the `commit_to` and `tag_to` change, since I’m not perfectly confident that this change is okay for all ways to execute `git-changelog`.
* You can run `rspec spec/` now. :)