### PR TITLE
Naming Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Currently, the following keynotes are supported
 * `fix`
 * `feat`
 * `gui`
-* `refactoring`
+* `refactor`
 
 ### Scope
 

--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -10,7 +10,7 @@ Commit messages are parsed for lines of the following format:
 `* fix: [<scope(optional)>] <description>`
 `* feat: [<scope(optional)>] <description>`
 `* gui: [<scope(optional)>] <description>`
-`* refactoring: [<scope(optional)>] <description>`
+`* refactor: [<scope(optional)>] <description>`
 
 The descriptions are collected and printed as changelog.
 

--- a/lib/changelog.rb
+++ b/lib/changelog.rb
@@ -2,10 +2,10 @@
 # over a certain timespan (between two commits)
 class Changelog
   def initialize(changes, tag_from = nil, tag_to = nil, from_commit = nil, to_commit = nil)
-    @fixes = changes.select { |c| c.type == Change::FIX }
-    @features = changes.select { |c| c.type == Change::FEAT }
-    @gui_changes = changes.select { |c| c.type == Change::GUI }
-    @refactorings = changes.select { |c| c.type == Change::REFACTORING }
+    @changes_fix = changes.select { |c| c.type == Change::FIX }
+    @changes_feat = changes.select { |c| c.type == Change::FEAT }
+    @changes_gui = changes.select { |c| c.type == Change::GUI }
+    @changes_refactor = changes.select { |c| c.type == Change::REFACTOR }
     @tag_from = tag_from
     @tag_to = tag_to
     @commit_from = from_commit
@@ -17,10 +17,10 @@ class Changelog
   # Each type is a list of changes where each change is the note of that change
   def changes
     {
-      fixes: @fixes.map(&:note),
-      features: @features.map(&:note),
-      gui: @gui_changes.map(&:note),
-      refactoring: @refactorings.map(&:note)
+      fix: @changes_fix.map(&:note),
+      feature: @changes_feat.map(&:note),
+      gui: @changes_gui.map(&:note),
+      refactor: @changes_refactor.map(&:note)
     }
   end
 

--- a/lib/changelog.rb
+++ b/lib/changelog.rb
@@ -12,6 +12,9 @@ class Changelog
     @commit_to = to_commit
   end
 
+  # Returns a hash of the changes.
+  # The changes are grouped by change type into `fix`, `feature`, `gui`, `refactor`
+  # Each type is a list of changes where each change is the note of that change
   def changes
     {
       fixes: @fixes.map(&:note),
@@ -81,6 +84,7 @@ class Changelog
     str
   end
 
+  # Render the Changelog with Slack Formatting
   def to_slack
     str = ""
 
@@ -95,6 +99,7 @@ class Changelog
     str
   end
 
+  # Render the Changelog with Markdown Formatting
   def to_md
     str = ""
 

--- a/lib/changelog_helpers.rb
+++ b/lib/changelog_helpers.rb
@@ -28,6 +28,11 @@ class Change
     @note
   end
 
+  # Parse a single line as a `Change` entry
+  # If the line is formatte correctly as a change entry, a corresponding `Change` object will be created and returned,
+  # otherwise, nil will be returned.
+  # 
+  # The additional scope can be used to skip changes of another scope. Changes without scope will always be included.
   def self.parse(line, scope = nil)
     if line.start_with? Change::TOKEN_FEAT
       self.new(Change::FEAT, line.split(Change::TOKEN_FEAT).last).check_scope(scope)
@@ -42,14 +47,16 @@ class Change
     end
   end
 
+  # Checks the scope of the `Change` and the change out if the scope does not match.
   def check_scope(scope = nil)
     # If no scope is requested or the change has no scope include this change unchanged
     return self unless scope
     change_scope = /^\s*\[\w+\]/.match(@note)
     return self unless change_scope
 
+    # change_scope is a string of format `[scope]`, need to strip the `[]` to compare the scope
     if change_scope[0][1..-2] == scope
-      #  Change has the scope that is requested, strip the scope from the change note
+      #  Change has the scope that is requested, strip the whole scope scope from the change note
       @note = change_scope.post_match.strip
       return self
     else
@@ -97,6 +104,7 @@ def parseCommit(commit, scope, logger)
   lines.map{|line| Change.parse(line, scope)}.reject(&:nil?)
 end
 
+# Searches the commit log messages of all commits between `commit_from` and `commit_to` for changes
 def searchGitLog(repo, commit_from, commit_to, scope, logger)
   logger.info("Traversing git tree from commit #{commit_from.oid} to commit #{commit_to && commit_to.oid}")
 

--- a/lib/changelog_helpers.rb
+++ b/lib/changelog_helpers.rb
@@ -8,12 +8,12 @@ class Change
   FIX = 1
   FEAT = 2
   GUI = 3
-  REFACTORING = 4
+  REFACTOR = 4
 
   TOKEN_FIX = "* fix:"
   TOKEN_FEAT = "* feat:"
   TOKEN_GUI = "* gui:"
-  TOKEN_REFACTORING = "* refactoring:"
+  TOKEN_REFACTOR = "* refactor:"
 
   def initialize(type, note)
     @type = type
@@ -40,8 +40,8 @@ class Change
       self.new(Change::FIX, line.split(Change::TOKEN_FIX).last).check_scope(scope)
     elsif line.start_with? Change::TOKEN_GUI
       self.new(Change::GUI, line.split(Change::TOKEN_GUI).last).check_scope(scope)
-    elsif line.start_with? Change::TOKEN_REFACTORING
-      self.new(Change::REFACTORING, line.split(Change::TOKEN_REFACTORING).last).check_scope(scope)
+    elsif line.start_with? Change::TOKEN_REFACTOR
+      self.new(Change::REFACTOR, line.split(Change::TOKEN_REFACTOR).last).check_scope(scope)
     else
       nil
     end

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -2,6 +2,60 @@ require 'spec_helper'
 require 'changelog'
 
 describe Changelog do
+  context "creating and using the changelog" do 
+    let(:change_feature_1) { "Feature 1"}
+    let(:change_feature_2) { "Feature 2"}
+    let(:change_fix_1) { "Fix 1"}
+    let(:change_gui_1) { "GUI 1"}
+    let(:changes) do 
+      [
+        Change.new(Change::FEAT, change_feature_1),
+        Change.new(Change::GUI, change_gui_1),
+        Change.new(Change::FEAT, change_feature_2),
+        Change.new(Change::FIX, change_fix_1),
+      ]
+    end
+    subject { Changelog.new(changes) }
+
+    context "output" do
+      context "slack format" do
+        it "should create some output and contain the given changes" do
+          expect(subject.to_slack).to include(change_feature_1)
+          expect(subject.to_slack).to include(change_feature_2)
+          expect(subject.to_slack).to include(change_fix_1)
+          expect(subject.to_slack).to include(change_gui_1)
+        end        
+      end
+
+      context "markdown format" do
+        it "should create some output and contain the given changes" do
+          expect(subject.to_md).to include(change_feature_1)
+          expect(subject.to_md).to include(change_feature_2)
+          expect(subject.to_md).to include(change_fix_1)
+          expect(subject.to_md).to include(change_gui_1)
+        end        
+      end
+
+      context "raw format" do
+        it "should create some output and contain the given changes" do
+          expect(subject.changes[:feature]).to include(change_feature_1)
+          expect(subject.changes[:feature]).to include(change_feature_2)
+          expect(subject.changes[:fix]).to include(change_fix_1)
+          expect(subject.changes[:gui]).to include(change_gui_1)
+          expect(subject.changes[:refactor]).to eq([])
+        end        
+      end
+
+      it "should return `Unrelease` as tag_info" do
+        expect(subject.tag_info{ |ti| "#{ti}" }).to eq("Unreleased")
+      end
+
+      it "should return an empty string as commit_info" do
+        expect(subject.commit_info{ |ci| "#{ci}" }).to eq("")
+      end
+    end
+  end
+
   context "without git information" do
     subject { Changelog.new([]) }
     let(:changes) do


### PR DESCRIPTION
* refactor: Token for a `refactor` change has been changed from `* refactoring` to `* refactor`
* refactor: Keys of the `change` getter have been changed from (`fixes`, `features`, `gui`, `refactoring`) to (`fix`, `feature`, `gui`, `refactor`)

* doc: add more documentation to methods
* test: add some basic test cases for usage of `Changelog` to the specs